### PR TITLE
Leagues & cookies

### DIFF
--- a/iRacingStats.Core/Constants/URLs.cs
+++ b/iRacingStats.Core/Constants/URLs.cs
@@ -49,5 +49,12 @@
         public const string TICKER_SESSIONS = MEMBER_SITE + "/GetTickerSessions";
         public const string SEASON_FOR_SESSION = MEMBER_SITE + "/GetSeasonForSession";
         public const string ALL_SUBSESSIONS = MEMBER_SITE + "/GetAllSubsessions";
+
+        // League endpoints
+        public const string LEAGUE_DIRECTORY = MEMBER_SITE + "/GetLeagueDirectory";
+        public const string LEAGUE_SESSIONS = MEMBER_SITE + "/GetLeagueSessions";
+        public const string LEAGUE_SEASON_SESSIONS = MEMBER_SITE + "/GetLeagueCalendarBySeason"; //leagueID, leagueSeasonID
+        public const string LEAGUE_SEASONS = MEMBER_SITE + "/GetLeagueSeasons"; //leagueID
+
     }
 }

--- a/iRacingStats.Core/Extensions/IServiceCollectionExtensions.cs
+++ b/iRacingStats.Core/Extensions/IServiceCollectionExtensions.cs
@@ -11,14 +11,12 @@ namespace iRacingStats.Core.Extensions
 
             services.Configure<User>(configuration.GetSection("iRacingStats.Core:User"));
             services.AddHttpClient<IRacingHttpClient>()
-                .ConfigureHttpMessageHandlerBuilder(c => {
-                    HttpClientHandler _ = new()
+                .ConfigureHttpMessageHandlerBuilder(c => new HttpClientHandler()
                     {
                         AllowAutoRedirect = true,
                         UseCookies = true,
                         CookieContainer = new CookieContainer()
-                    };
-                });
+                    });
             return services;
         }
     }

--- a/iRacingStats.Core/HttpClients/IRacingHttpClient.cs
+++ b/iRacingStats.Core/HttpClients/IRacingHttpClient.cs
@@ -89,7 +89,7 @@ namespace iRacingStats.Core.HttpClients
 			}
 
 			HttpRequestMessage request = new(HttpMethod.Get, new Uri(QueryHelpers.AddQueryString(url, formData)));
-			request.Headers.Add("Cookie", cookies);
+			//request.Headers.Add("Cookie", cookies);
 
 			HttpResponseMessage response = await _httpClient.SendAsync(request);
 

--- a/iRacingStats.Core/Models/Car.cs
+++ b/iRacingStats.Core/Models/Car.cs
@@ -1,0 +1,10 @@
+﻿namespace iRacingStats.Core.Models
+{
+    public class Car
+    {
+        public string car_name { get; set; }
+        public int carclassid { get; set; }
+        public string carclass_name { get; set; }
+        public int carid { get; set; }
+    }
+}

--- a/iRacingStats.Core/Models/Leagues/League.cs
+++ b/iRacingStats.Core/Models/Leagues/League.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace iRacingStats.Core.Models.Leagues
+{
+    public class League
+    {
+        [JsonPropertyName("1")]
+        public string LeagueName { get; set; } = string.Empty;
+
+        [JsonPropertyName("3")]
+        public long Created { get; set; }
+
+        [JsonPropertyName("4")]
+        public string About { get; set; } = string.Empty;
+
+        [JsonPropertyName("5")]
+        public int Pattern { get; set; }
+
+        [JsonPropertyName("6")]
+        public int Admin { get; set; }
+
+        [JsonPropertyName("7")]
+        public int PendingApplciation { get; set; }
+
+        [JsonPropertyName("8")]
+        public int LicenceLevel { get; set; }
+
+        [JsonPropertyName("9")]
+        public string Url { get; set; } = string.Empty;
+
+        [JsonPropertyName("10")]
+        public string Color3 { get; set; } = string.Empty;
+
+        [JsonPropertyName("11")]
+        public int Relevance { get; set; }
+
+        [JsonPropertyName("12")]
+        public string Color1 { get; set; } = string.Empty;
+
+        [JsonPropertyName("13")]
+        public string Color2 { get; set; } = string.Empty;
+
+        [JsonPropertyName("14")]
+        public int LeagueId { get; set; }
+
+        [JsonPropertyName("15")]
+        public string SortingName { get; set; } = string.Empty;
+
+        [JsonPropertyName("16")]
+        public int Recruiting { get; set; }
+
+        [JsonPropertyName("17")]
+        public string DisplayName { get; set; } = string.Empty;
+
+        [JsonPropertyName("18")]
+        public int PendingInvitation { get; set; }
+
+        [JsonPropertyName("19")]
+        public int Member { get; set; }
+
+        [JsonPropertyName("20")]
+        public int CustId { get; set; } 
+
+        [JsonPropertyName("21")]
+        public int RN { get; set; }
+
+        [JsonPropertyName("22")]
+        public int RosterCount { get; set; }
+
+    }
+}

--- a/iRacingStats.Core/Models/Leagues/LeagueRace.cs
+++ b/iRacingStats.Core/Models/Leagues/LeagueRace.cs
@@ -1,0 +1,100 @@
+﻿namespace iRacingStats.Core.Models.Leagues
+{
+    public class LeagueRace
+    {
+        public int practicedur { get; set; }
+        public string reason { get; set; } = string.Empty;
+        public string hs_mainsessionlenmins { get; set; } = string.Empty;
+        public string hs_mainnumlaps { get; set; } = string.Empty;
+        public int league_season_id { get; set; }
+        public int warmuplength { get; set; }
+        public int qualdur { get; set; }
+        public int weather_temp_units { get; set; }
+        public int weather_wind_dir { get; set; }
+        public string hs_prequalpracticelenmins { get; set; } = string.Empty;
+        public int weather_temp_value { get; set; }
+        public string hs_consolfirstsessionnumlaps { get; set; } = string.Empty;
+        public string hs_qualscoreschamppoints { get; set; } = string.Empty;
+        public int privatesessionid { get; set; }
+        public object sessionid { get; set; } = string.Empty;
+        public string hs_heatnumpostoinvert { get; set; } = string.Empty;
+        public string hs_heatmaxfieldsize { get; set; } = string.Empty;
+        public int practicelength { get; set; }
+        public string hs_is_hidden { get; set; } = string.Empty;
+        public string hs_custid { get; set; } = string.Empty;
+        public string hs_heatinfoname { get; set; } = string.Empty;
+        public string hs_heatnumlaps { get; set; } = string.Empty;
+        public int qualifylength { get; set; }
+        public int weather_fog_density { get; set; }
+        public string hs_consolnumpostoinvert { get; set; } = string.Empty;
+        public string hs_heatinfoid { get; set; } = string.Empty;
+        public string hs_mainnumpostoinvert { get; set; } = string.Empty;
+        public string hs_prequalnumtomain { get; set; } = string.Empty;
+        public string hs_heatnumfromeachtomain { get; set; } = string.Empty;
+        public string hs_practiceisopen { get; set; } = string.Empty;
+        public string hs_racestyle { get; set; } = string.Empty;
+        public string hs_heatcautiontype { get; set; } = string.Empty;
+        public List<Car> cars { get; set; } = new List<Car>();
+        public string hs_consolscoreschamppoints { get; set; } = string.Empty;
+        public int leagueid { get; set; }
+        public string hs_qualopendelaysecs { get; set; } = string.Empty;
+        public object launchat { get; set; } = string.Empty;
+        public int rn { get; set; }
+        public int racelaps { get; set; }
+        public int racedur { get; set; }
+        public int status { get; set; }
+        public object winnersgroupid { get; set; } = string.Empty;
+        public string hs_qualnumlaps { get; set; } = string.Empty;
+        public string qualtype { get; set; } = string.Empty;
+        public int hs_created { get; set; }
+        public int trackid { get; set; }
+        public int weather_type { get; set; }
+        public string hs_consolfirstsessionlenmins { get; set; } = string.Empty;
+        public int hasresults { get; set; }
+        public int rubberlevel_race { get; set; }
+        public int qualifylaps { get; set; }
+        public int rubberlevel_practice { get; set; }
+        public int weather_skies { get; set; }
+        public int grip_compound_practice { get; set; }
+        public string hs_consoldeltamaxfieldsize { get; set; } = string.Empty;
+        public int weather_var_ongoing { get; set; }
+        public string hs_maxentrants { get; set; } = string.Empty;
+        public string hs_qualstyle { get; set; } = string.Empty;
+        public int grip_compound_qualify { get; set; }
+        public string hs_consolnumtoconsolation { get; set; } = string.Empty;
+        public string hs_consoldeltasessionnumlaps { get; set; } = string.Empty;
+        public object subsessionid { get; set; } = string.Empty;
+        public int leavemarbles { get; set; }
+        public int rubberlevel_qualify { get; set; }
+        public string track_name { get; set; } = string.Empty;
+        public string hs_description { get; set; } = string.Empty;
+        public string config_name { get; set; } = string.Empty;
+        public int weather_rh { get; set; }
+        public string hs_imageurl { get; set; } = string.Empty;
+        public int weather_var_initial { get; set; }
+        public string hs_consolnumtomain { get; set; } = string.Empty;
+        public int warmupdur { get; set; }
+        public string hs_qualscoring { get; set; } = string.Empty;
+        public int racelength { get; set; }
+        public string hs_consoldeltasessionlenmins { get; set; } = string.Empty;
+        public int timelimit { get; set; }
+        public string hs_consolrunalways { get; set; } = string.Empty;
+        public string hs_qualsessionlenmins { get; set; } = string.Empty;
+        public int lonequalify { get; set; }
+        public int rubberlevel_warmup { get; set; }
+        public string hs_qualcautiontype { get; set; } = string.Empty;
+        public string hs_premainpracticelenmins { get; set; } = string.Empty;
+        public int weather_wind_speed_value { get; set; }
+        public string hs_qualnumtomain { get; set; } = string.Empty;
+        public string hs_heatsessionlenmins { get; set; } = string.Empty;
+        public string hs_heatscoreschamppoints { get; set; } = string.Empty;
+        public int grip_compound_warmup { get; set; }
+        public string hs_mainmaxfieldsize { get; set; } = string.Empty;
+        public int grip_compound_race { get; set; }
+        public int driver_changes { get; set; }
+        public string winnername { get; set; } = string.Empty;
+        public int weather_wind_speed_units { get; set; }
+        public string hs_consolfirstmaxfieldsize { get; set; } = string.Empty;
+    }
+   
+}

--- a/iRacingStats.Core/Models/Leagues/LeagueSeason.cs
+++ b/iRacingStats.Core/Models/Leagues/LeagueSeason.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.Json.Serialization;
+
+namespace iRacingStats.Core.Models.Leagues
+{
+    public class LeagueSeason
+    {
+        [JsonPropertyName("1")]
+        public int LeagueSeasonId { get; set; } 
+
+        [JsonPropertyName("2")]
+        public string LeaguePointsSystemName { get; set; } = string.Empty;
+
+        [JsonPropertyName("3")]
+        public int Hidden { get; set; } 
+
+        [JsonPropertyName("5")]
+        public int LeaguePointsSystemId { get; set; }
+
+        [JsonPropertyName("6")]
+        public int Actice { get; set; }
+
+        [JsonPropertyName("7")]
+        public int UseLmt { get; set; }
+
+        [JsonPropertyName("8")]
+        public string LeagueSeasonName { get; set; } = string.Empty;
+
+        [JsonPropertyName("9")]
+        public int NumDrops { get; set; }
+
+        //[JsonPropertyName("10")]
+        //public LeagueRace NextRace { get; set; } = new LeagueRace();
+
+        [JsonPropertyName("11")]
+        public int LeagueId { get; set; } 
+
+        [JsonPropertyName("12")]
+        public int RN { get; set; }
+
+        //[JsonPropertyName("13")]
+        //public LeagueRace PreviousRace { get; set; } = new LeagueRace();
+
+        [JsonPropertyName("14")]
+        public string LeaguePointSystemDesc { get; set; } = string.Empty;
+
+        [JsonPropertyName("15")]
+        public string NoDropsOnOrAfterRaceNum { get; set; } = string.Empty;
+    }
+}

--- a/iRacingStats.Core/Models/iRacingModelData.cs
+++ b/iRacingStats.Core/Models/iRacingModelData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace iRacingStats.Core.Models
 {
@@ -8,5 +9,26 @@ namespace iRacingStats.Core.Models
     {
         public object m { get; set; }
         public List<T> d { get; set; }
+    }
+
+    public class iRacingModelRowData<T>
+    {
+        public object m { get; set; }
+        public RowData<T> d { get; set; }
+    }
+
+    public class RowData<T>
+    {
+        [JsonPropertyName("2")]
+        public int RowCount { get; set; }
+        [JsonPropertyName("r")]
+        public List<T> Rows { get; set; }
+    }
+    public class RowDataActual<T>
+    {
+        [JsonPropertyName("rowcount")]
+        public int RowCount { get; set; }
+        [JsonPropertyName("rows")]
+        public List<T> Rows { get; set; }
     }
 }

--- a/iRacingStatsAPI/Controllers/Leagues/LeagueController.cs
+++ b/iRacingStatsAPI/Controllers/Leagues/LeagueController.cs
@@ -1,0 +1,58 @@
+﻿using iRacingStats.Core.HttpClients;
+using iRacingStats.Core.Constants;
+using iRacingStats.Core.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using iRacingStats.Core.Models.Leagues;
+
+namespace iRacingStats.Api.Controllers.Stats
+{
+    [Route("api/stats/[controller]")]
+    [ApiController]
+    public class LeagueController : ControllerBase
+    {
+        private readonly IRacingHttpClient _iracingHttpClient;
+
+        public LeagueController(IRacingHttpClient iracingHttpClient)
+        {
+            _iracingHttpClient = iracingHttpClient;
+        }
+
+        [HttpGet]
+        public async Task<iRacingModelRowData<League>> GetLeagues()
+        {
+            Dictionary<string, string> data = new()
+            {
+                { "restrictToMember", "1" },
+                { "lowerbound", "1" },
+                { "upperbound", "22" }
+            };
+
+            return await _iracingHttpClient.PostRequestAndGetResponse<iRacingModelRowData<League>>(URLs.LEAGUE_DIRECTORY, data);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<iRacingModelRowData<LeagueSeason>> GetSeasons(int id)
+        {
+            Dictionary<string, string> data = new()
+            {
+                { "leagueID", id.ToString() }
+            };
+
+            return await _iracingHttpClient.PostRequestAndGetResponse<iRacingModelRowData<LeagueSeason>>(URLs.LEAGUE_SEASONS, data);
+        }
+
+        [HttpGet("{id}/{season}")]
+        public async Task<RowDataActual<LeagueRace>> GetSeasonSessions(int id, int season)
+        {
+            Dictionary<string, string> data = new()
+            {
+                { "leagueID", id.ToString() },
+                { "leagueSeasonID", season.ToString() }
+            };
+
+            return await _iracingHttpClient.PostRequestAndGetResponse<RowDataActual<LeagueRace>>(URLs.LEAGUE_SEASON_SESSIONS, data);
+        }
+    }
+}


### PR DESCRIPTION
Added a few league endpoints

There is an "interesting" feature in the API which messes with the iRacingModelData structure, I need to think of a better way but this works and yes there are two different types of row data one with a number and one with field names... thanks serialisation

COOKIES::
Okay so been looking around and changed a little (again) to see if it works this time. It "works on my machine"